### PR TITLE
Add missing dependency to Fedora build instructions

### DIFF
--- a/views/quickstart/installLinuxDistro.marko
+++ b/views/quickstart/installLinuxDistro.marko
@@ -35,7 +35,7 @@ sudo apt-get install openrct2</pre>
         <p>You will need the dependencies to build the game - there is no package for the game as of yet.</p>
         <pre class="code">sudo dnf install gcc gcc-c++ jansson-devel \
 SDL2_ttf-devel openssl-devel \
-speexdsp-devel libcurl-devel \
+speexdsp-devel libcurl-devel libicu-devel \
 cmake fontconfig-devel freetype-devel \
 libpng-devel libzip-devel mesa-libGL-devel</pre>
         <h2>Build the game</h2>


### PR DESCRIPTION
`libicu-devel` is not present on a fresh install of Fedora 28. (Neither is `git`, for that matter, but that's a little harder to miss.)