### PR TITLE
Reword Arch Linux Install Instructions

### DIFF
--- a/views/quickstart/installLinuxDistro.marko
+++ b/views/quickstart/installLinuxDistro.marko
@@ -4,10 +4,8 @@
     <h1><img src="/assets/images/icons/linux.svg" alt="Linux icon"> <span><b>Install OpenRCT2 on ${data.distro.title}</b> - Quickstart Guide</span></h1>
     <if(data.distroIdentifier === 'arch-linux')>
         <h2>Install OpenRCT2</h2>
-        <p>If you want to install the latest release - stable, well-tested, but might have fewer features than the latest development build, install the standard package by running the following command.</p>
-        <pre class="code">yaourt -S openrct2</pre>
-        <p>Alternatively, if you want the latest development build, install the -git package from the AUR. The development builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
-        <pre class="code">yaourt -S openrct2-git</pre>
+        <p>If you want to install the latest release - stable, well-tested, but might have fewer features than the latest development build, <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages">install</a> the <span class="monospace"><a href="https://aur.archlinux.org/packages/openrct2/">openrct2</a></span> package from the <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository">AUR</a>.</p>
+        <p>Alternatively, if you want the latest development build, <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages">install</a> the <span class="monospace"><a href="https://aur.archlinux.org/packages/openrct2-git">openrct2-git</a></span> package from the <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository">AUR</a>. The development builds are analogous to beta versions - they should work, but don't expect everything to be perfect.</p>
     </if>
     <else-if(data.distroIdentifier === 'openSUSE')>
         <h2>Install OpenRCT2</h2>


### PR DESCRIPTION
Problems I see:
 - Yaourt is unmaintained and shouldn't be used anymore.
 - It is recommended that new arch users build AUR packages from scratch instead of using helpers. They need to understand what is going on behind the scenes before using a helper.
 - The AUR can potentially hold malicious code and build scripts so we shouldn't encourage users to blindly install things from it.

My Solutions:
Removed all mention to an AUR helper. People who are comfortable with the AUR only need the package name to install it.  For those who are inexperienced, links to the wiki have been given. They need to understand exactly what the AUR is and how to use it safely before installing packages.