### PR TITLE
Reword download page

### DIFF
--- a/src/http/routes/downloads/downloadsIndex.marko
+++ b/src/http/routes/downloads/downloadsIndex.marko
@@ -16,7 +16,7 @@ $ {
       <section>
         <h1>OpenRCT2 Downloads</h1>
         <p class="lead">
-          OpenRCT2 has frequent stable releases. However, it is also possible to download unstable
+          OpenRCT2 has frequent releases. However, it is also possible to download
           <i>development</i>
           builds and playtest
           <a href="/changelog" title="Read about the latest features and changes on the changelog page">the latest features and changes</a>.
@@ -38,7 +38,7 @@ $ {
             <div>
               <h2>Releases</h2>
               <p>
-                Thoroughly tested releases with minimal bugs and crashes. ${data.lastRelease.version} released
+                Generally stable releases. Updated every few months. ${data.lastRelease.version} released
                 <span class="fromNow titleDate" data-date=data.lastRelease.published.toISOString() data-format="llll">${fromNowDate(data.lastRelease.published)}</span>.
               </p>
               <p class="textCenter">


### PR DESCRIPTION
While we are generally more cautious around releasing, we very specifically don't call our releases “stable”. Reflect this on the download page.