### PR TITLE
Update linux build identification

### DIFF
--- a/src/misc/releaseAsset.js
+++ b/src/misc/releaseAsset.js
@@ -107,7 +107,7 @@ export class ReleaseAsset {
     } else if (this.fileName.includes('-focal')) {
       this.platform = 'Ubuntu Focal 20.04';
       this.category = 'linux'; // Force category
-    } else if (this.fileName.includes('-bionic') || (this.fileName.includes('-linux') && !this.fileName.endsWith('.AppImage'))) {
+    } else if (this.fileName.includes('-bionic') || ((this.fileName.includes('-linux') && !this.fileName.endsWith('.AppImage')))) {
       this.platform = 'Ubuntu Bionic 18.04';
       this.category = 'linux'; // Force category
     } else if (this.fileName.includes('-bullseye')) {


### PR DESCRIPTION
Currently Debian Bullseye gets misidentified.

![image](https://user-images.githubusercontent.com/550290/223139352-e0b238d7-1f48-458c-923b-51532ccbda1a.png)
