### PR TITLE
Remove macOS from automatic updates section of download page

### DIFF
--- a/views/downloads/index.eta
+++ b/views/downloads/index.eta
@@ -46,7 +46,7 @@
         <h2>Automatic updates</h2>
         <p>The community provides a launcher which auto-updates OpenRCT2 whenever an update is made available.</p>
         <p class="textCenter">
-          <a href="https://github.com/IntelOrca/OpenLauncher/releases/latest" target="_blank">Launcher for Windows, macOS or Linux</a>
+          <a href="https://github.com/IntelOrca/OpenLauncher/releases/latest" target="_blank">Launcher for Windows or Linux</a>
         </p>
       </div>
       <div>


### PR DESCRIPTION
The linked launcher isn't available for macOS.